### PR TITLE
systemd installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # travis-enterprise-worker-installers
 Installer scripts for the Travis CI Enterprise Worker machines
+
+## installer.sh
+
+This is the default systemd-enabled installer we're using for Ubuntu 16.04 and later. This uses `overlay2` as storage driver which performs better than `aufs` and requires less setup than `devicemapper`.
+
+This installer requires a machine with these minimum specs:
+
+- 8 CPU Cores
+- 16Gig RAM
+- At least 40GB HDD
+- Ubuntu 16.04
+
+On AWS EC2 the `c4.2xlarge` and bigger are a good fit. _Please note: You need to configure the harddisk capacity manually._

--- a/installer.sh
+++ b/installer.sh
@@ -190,3 +190,39 @@ pull_build_images() {
 if [[ ! -n $SKIP_DOCKER_POPULATE ]]; then
   docker_populate_images
 fi
+
+configure_travis_worker() {
+  TRAVIS_ENTERPRISE_CONFIG="/etc/default/travis-enterprise"
+  TRAVIS_WORKER_CONFIG="/etc/default/travis-worker"
+
+  # Trusty images don't seem to like SSH
+  echo "export TRAVIS_WORKER_DOCKER_NATIVE=\"true\"" >> $TRAVIS_WORKER_CONFIG
+  echo "export AMQP_URI=\"amqp://travis:${TRAVIS_ENTERPRISE_SECURITY_TOKEN:-travis}@${TRAVIS_ENTERPRISE_HOST:-localhost}/travis\"" >> $TRAVIS_WORKER_CONFIG
+  echo "export BUILD_API_URI=\"https://${TRAVIS_ENTERPRISE_HOST:-localhost}/${TRAVIS_ENTERPRISE_BUILD_ENDPOINT:-}/script\"" >> $TRAVIS_WORKER_CONFIG
+  echo "export TRAVIS_WORKER_BUILD_API_INSECURE_SKIP_VERIFY='true'" >> $TRAVIS_WORKER_CONFIG
+  echo "export POOL_SIZE='2'" >> $TRAVIS_WORKER_CONFIG
+  echo "export PROVIDER_NAME='docker'" >> $TRAVIS_WORKER_CONFIG
+  echo "export TRAVIS_WORKER_DOCKER_ENDPOINT='tcp://localhost:4243'" >> $TRAVIS_WORKER_CONFIG
+
+  if [[ -n $TRAVIS_ENTERPRISE_HOST ]]; then
+    echo "export TRAVIS_ENTERPRISE_HOST=\"$TRAVIS_ENTERPRISE_HOST\"" >> $TRAVIS_ENTERPRISE_CONFIG
+  fi
+
+  if [[ -n $TRAVIS_ENTERPRISE_SECURITY_TOKEN ]]; then
+    echo "export TRAVIS_ENTERPRISE_SECURITY_TOKEN=\"$TRAVIS_ENTERPRISE_SECURITY_TOKEN\"" >> $TRAVIS_ENTERPRISE_CONFIG
+  fi
+
+  if [[ -n $TRAVIS_ENTERPRISE_BUILD_ENDPOINT ]]; then
+    echo "export TRAVIS_ENTERPRISE_BUILD_ENDPOINT=\"$TRAVIS_ENTERPRISE_BUILD_ENDPOINT\"" >> $TRAVIS_ENTERPRISE_CONFIG
+  else
+    echo "export TRAVIS_ENTERPRISE_BUILD_ENDPOINT=\"__build__\"" >> $TRAVIS_ENTERPRISE_CONFIG
+  fi
+
+  if [[ -n $TRAVIS_QUEUE_NAME ]]; then
+    echo "export QUEUE_NAME='$TRAVIS_QUEUE_NAME'" >> $TRAVIS_WORKER_CONFIG
+  else
+    echo "export QUEUE_NAME='builds.trusty'" >> $TRAVIS_WORKER_CONFIG
+  fi
+}
+
+configure_travis_worker

--- a/installer.sh
+++ b/installer.sh
@@ -132,14 +132,16 @@ install_travis_worker_wrapper
 
 # Installs the systemd service file for travis-worker
 install_travis_worker_service_file() {
-  adduser \
-  --system \
-  --shell /bin/false \
-  --gecos 'Service user for running travis-worker' \
-  --group \
-  --disabled-password \
-  --no-create-home \
-  travis
+  if ! id -u 'travis' > /dev/null 2>&1; then
+    adduser \
+    --system \
+    --shell /bin/false \
+    --gecos 'Service user for running travis-worker' \
+    --group \
+    --disabled-password \
+    --no-create-home \
+    travis
+  fi
 
   curl -fsSL 'https://raw.githubusercontent.com/travis-ci/terraform-config/master/assets/travis-worker/travis-worker.service' > /etc/systemd/system/multi-user.target.wants/travis-worker.service
   systemctl daemon-reload

--- a/installer.sh
+++ b/installer.sh
@@ -106,12 +106,9 @@ docker_setup() {
     apt-get install -y docker-ce=$DOCKER_VERSION
   fi
 
-  # use LXC, and disable inter-container communication
-  if [[ ! $(grep icc $DOCKER_CONFIG_FILE) ]]; then
-    echo 'DOCKER_OPTS="--icc=false '$DOCKER_MOUNT_POINT'"' >> $DOCKER_CONFIG_FILE
-    systemctl restart docker
-    sleep 2 # a short pause to ensure the docker daemon starts
-  fi
+  jq -n '{"storage-driver": "overlay2", "icc": false, "log-driver": "journald"}' > /etc/docker/daemon.json
+  systemctl restart docker
+  sleep 2 # a short pause to ensure the docker daemon starts
 }
 
 docker_setup

--- a/installer.sh
+++ b/installer.sh
@@ -107,3 +107,11 @@ docker_setup() {
 }
 
 docker_setup
+
+# Installs the travis-tfw-combined-env commandline tool
+install_travis_tfw_combined_env() {
+  curl -fsSL 'https://raw.githubusercontent.com/travis-ci/terraform-config/master/assets/tfw/usr/local/bin/travis-tfw-combined-env' > /usr/local/bin/travis-tfw-combined-env
+  chmod +x /usr/local/bin/travis-tfw-combined-env
+}
+
+install_travis_tfw_combined_env

--- a/installer.sh
+++ b/installer.sh
@@ -149,6 +149,9 @@ install_travis_worker_service_file() {
   fi
 
   curl -fsSL 'https://raw.githubusercontent.com/travis-ci/terraform-config/master/assets/travis-worker/travis-worker.service' > /etc/systemd/system/multi-user.target.wants/travis-worker.service
+  mkdir -p /etc/systemd/system/travis-worker.service.d
+  echo "[Service]" > /etc/systemd/system/travis-worker.service.d/env.conf
+  echo "Environment=\"TRAVIS_WORKER_SELF_IMAGE=travisci/worker:$TRAVIS_WORKER_VERSION\"" >> /etc/systemd/system/travis-worker.service.d/env.conf
   systemctl daemon-reload
 }
 
@@ -157,8 +160,6 @@ install_travis_worker_service_file
 # Pulls down the travis-worker image
 install_travis_worker() {
   docker pull travisci/worker:$TRAVIS_WORKER_VERSION
-  echo "TRAVIS_WORKER_SELF_IMAGE=travisci/worker:$TRAVIS_WORKER_VERSION" >> /etc/environment
-  source /etc/environment
 }
 
 install_travis_worker

--- a/installer.sh
+++ b/installer.sh
@@ -123,3 +123,20 @@ install_travis_worker_wrapper() {
 }
 
 install_travis_worker_wrapper
+
+# Installs the systemd service file for travis-worker
+install_travis_worker_service_file() {
+  adduser \
+  --system \
+  --shell /bin/false \
+  --gecos 'Service user for running travis-worker' \
+  --group \
+  --disabled-password \
+  --no-create-home \
+  travis
+
+  curl -fsSL 'https://raw.githubusercontent.com/travis-ci/terraform-config/master/assets/travis-worker/travis-worker.service' > /etc/systemd/system/multi-user.target.wants/travis-worker.service
+  systemctl daemon-reload
+}
+
+install_travis_worker_service_file

--- a/installer.sh
+++ b/installer.sh
@@ -103,9 +103,7 @@ docker_setup() {
   apt-get update
 
   if ! docker version &>/dev/null; then
-    apt-get install -y \
-      "linux-image-extra-$(uname -r)" \
-      docker-ce=$DOCKER_VERSION
+    apt-get install -y docker-ce=$DOCKER_VERSION
   fi
 
   # use LXC, and disable inter-container communication

--- a/installer.sh
+++ b/installer.sh
@@ -190,7 +190,7 @@ pull_build_images() {
 }
 
 if [[ ! -n $SKIP_DOCKER_POPULATE ]]; then
-  docker_populate_images
+  pull_build_images
 fi
 
 configure_travis_worker() {

--- a/installer.sh
+++ b/installer.sh
@@ -110,7 +110,7 @@ docker_setup() {
 
   # use LXC, and disable inter-container communication
   if [[ ! $(grep icc $DOCKER_CONFIG_FILE) ]]; then
-    echo 'DOCKER_OPTS="-H tcp://127.0.0.1:4243 -H unix:///var/run/docker.sock --icc=false '$DOCKER_MOUNT_POINT'"' >> $DOCKER_CONFIG_FILE
+    echo 'DOCKER_OPTS="--icc=false '$DOCKER_MOUNT_POINT'"' >> $DOCKER_CONFIG_FILE
     systemctl restart docker
     sleep 2 # a short pause to ensure the docker daemon starts
   fi

--- a/installer.sh
+++ b/installer.sh
@@ -156,6 +156,8 @@ install_travis_worker_service_file
 # Pulls down the travis-worker image
 install_travis_worker() {
   docker pull travisci/worker:$TRAVIS_WORKER_VERSION
+  echo "TRAVIS_WORKER_SELF_IMAGE=travisci/worker:$TRAVIS_WORKER_VERSION" >> /etc/environment
+  source /etc/environment
 }
 
 install_travis_worker

--- a/installer.sh
+++ b/installer.sh
@@ -115,3 +115,11 @@ install_travis_tfw_combined_env() {
 }
 
 install_travis_tfw_combined_env
+
+# Installs the wrapper script for running travis-worker
+install_travis_worker_wrapper() {
+  curl -fsSL 'https://raw.githubusercontent.com/travis-ci/terraform-config/master/assets/travis-worker/travis-worker-wrapper' > /usr/local/bin/travis-worker-wrapper
+  chmod +x /usr/local/bin/travis-worker-wrapper
+}
+
+install_travis_worker_wrapper

--- a/installer.sh
+++ b/installer.sh
@@ -116,8 +116,8 @@ docker_setup
 
 # Installs the travis-tfw-combined-env commandline tool
 install_travis_tfw_combined_env() {
-  curl -fsSL 'https://raw.githubusercontent.com/travis-ci/terraform-config/master/assets/tfw/usr/local/bin/travis-tfw-combined-env' > /usr/local/bin/travis-tfw-combined-env
-  chmod +x /usr/local/bin/travis-tfw-combined-env
+  curl -fsSL 'https://raw.githubusercontent.com/travis-ci/terraform-config/master/assets/tfw/usr/local/bin/travis-tfw-combined-env' > /usr/local/bin/travis-combined-env
+  chmod +x /usr/local/bin/travis-combined-env
 }
 
 install_travis_tfw_combined_env

--- a/installer.sh
+++ b/installer.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+## Some environment setup
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+##
+
+## Handle Arguments
+
+if [[ ! -n $1 ]]; then
+  echo "No arguments provided, installing with"
+  echo "default configuration values."
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --travis_worker_version=*)
+      TRAVIS_WORKER_VERSION="${1#*=}"
+      ;;
+    --docker_version=*)
+      DOCKER_VERSION="${1#*=}"
+      ;;
+    --aws=*)
+      AWS="${1#*=}"
+      ;;
+    --travis_enterprise_host=*)
+      TRAVIS_ENTERPRISE_HOST="${1#*=}"
+      ;;
+    --travis_enterprise_security_token=*)
+      TRAVIS_ENTERPRISE_SECURITY_TOKEN="${1#*=}"
+      ;;
+    --travis_enterprise_build_endpoint=*)
+      TRAVIS_ENTERPRISE_BUILD_ENDPOINT="${1#*=}"
+      ;;
+    --travis_queue_name=*)
+      TRAVIS_QUEUE_NAME="${1#*=}"
+      ;;
+    --skip_docker_populate=*)
+      SKIP_DOCKER_POPULATE="${1#*=}"
+      ;;
+    *)
+      printf "*************************************************************\n"
+      printf "* Error: Invalid argument.                                  *\n"
+      printf "* Valid Arguments are:                                      *\n"
+      printf "*  --travis_worker_version=x.x.x                            *\n"
+      printf "*  --docker_version=x.x.x                                   *\n"
+      printf "*  --aws=true                                               *\n"
+      printf "*  --travis_enterprise_host="demo.enterprise.travis-ci.com" *\n"
+      printf "*  --travis_enterprise_security_token="token123"            *\n"
+      printf "*  --travis_enterprise_build_endpoint="build-api"           *\n"
+      printf "*  --travis_queue_name="builds.linux"                       *\n"
+      printf "*  --skip_docker_populate=true                              *\n"
+      printf "*************************************************************\n"
+      exit 1
+  esac
+  shift
+done
+
+if [[ ! -n $DOCKER_VERSION ]]; then
+  export DOCKER_VERSION="17.12.0~ce-0~ubuntu"
+else
+  export DOCKER_VERSION
+fi
+
+## We only want to run as root
+root_check() {
+  if [[ $(whoami) != "root" ]]; then
+    echo "This should only be run as root"
+    exit 1
+  fi
+}
+
+root_check
+##
+
+## Install and setup Docker
+docker_setup() {
+
+  : "${DOCKER_APT_FILE:=/etc/apt/sources.list.d/docker.list}"
+  : "${DOCKER_CONFIG_FILE:=/etc/default/docker}"
+
+  apt-get install -y apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
+
+  if [[ ! -f $DOCKER_APT_FILE ]]; then
+    curl -fsSL 'https://download.docker.com/linux/ubuntu/gpg' | apt-key add -
+    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  fi
+
+  apt-get update
+
+  if ! docker version &>/dev/null; then
+    apt-get install -y \
+      "linux-image-extra-$(uname -r)" \
+      docker-ce=$DOCKER_VERSION
+  fi
+
+  # use LXC, and disable inter-container communication
+  if [[ ! $(grep icc $DOCKER_CONFIG_FILE) ]]; then
+    echo 'DOCKER_OPTS="-H tcp://127.0.0.1:4243 -H unix:///var/run/docker.sock --icc=false '$DOCKER_MOUNT_POINT'"' >> $DOCKER_CONFIG_FILE
+    systemctl restart docker
+    sleep 2 # a short pause to ensure the docker daemon starts
+  fi
+}
+
+docker_setup

--- a/installer.sh
+++ b/installer.sh
@@ -21,9 +21,6 @@ while [ $# -gt 0 ]; do
     --docker_version=*)
       DOCKER_VERSION="${1#*=}"
       ;;
-    --aws=*)
-      AWS="${1#*=}"
-      ;;
     --travis_enterprise_host=*)
       TRAVIS_ENTERPRISE_HOST="${1#*=}"
       ;;
@@ -45,7 +42,6 @@ while [ $# -gt 0 ]; do
       printf "* Valid Arguments are:                                      *\n"
       printf "*  --travis_worker_version=x.x.x                            *\n"
       printf "*  --docker_version=x.x.x                                   *\n"
-      printf "*  --aws=true                                               *\n"
       printf "*  --travis_enterprise_host="demo.enterprise.travis-ci.com" *\n"
       printf "*  --travis_enterprise_security_token="token123"            *\n"
       printf "*  --travis_enterprise_build_endpoint="build-api"           *\n"

--- a/installer.sh
+++ b/installer.sh
@@ -145,6 +145,9 @@ install_travis_worker_service_file() {
     --disabled-password \
     --no-create-home \
     travis
+
+    #travis needs to be in the docker group to execute docker
+    usermod -aG docker travis
   fi
 
   curl -fsSL 'https://raw.githubusercontent.com/travis-ci/terraform-config/master/assets/travis-worker/travis-worker.service' > /etc/systemd/system/multi-user.target.wants/travis-worker.service

--- a/installer.sh
+++ b/installer.sh
@@ -225,3 +225,14 @@ configure_travis_worker() {
 }
 
 configure_travis_worker
+
+
+## Give travis-worker a kick to ensure the
+## latest config is picked up
+if [[ $(pgrep travis-worker) ]]; then
+  systemctl stop travis-worker
+fi
+systemctl start travis-worker
+
+echo 'Installation complete.'
+echo 'It is recommended that this host is restarted before running jobs through it'

--- a/installer.sh
+++ b/installer.sh
@@ -63,6 +63,12 @@ else
   export DOCKER_VERSION
 fi
 
+if [[ ! -n $TRAVIS_WORKER_VERSION ]]; then
+  export TRAVIS_WORKER_VERSION="v3.5.0"
+else
+  export TRAVIS_WORKER_VERSION
+fi
+
 ## We only want to run as root
 root_check() {
   if [[ $(whoami) != "root" ]]; then
@@ -140,3 +146,10 @@ install_travis_worker_service_file() {
 }
 
 install_travis_worker_service_file
+
+# Pulls down the travis-worker image
+install_travis_worker() {
+  docker pull travisci/worker:$TRAVIS_WORKER_VERSION
+}
+
+install_travis_worker

--- a/installer.sh
+++ b/installer.sh
@@ -80,16 +80,20 @@ root_check() {
 root_check
 ##
 
-## Install and setup Docker
-docker_setup() {
-
-  : "${DOCKER_APT_FILE:=/etc/apt/sources.list.d/docker.list}"
-  : "${DOCKER_CONFIG_FILE:=/etc/default/docker}"
-
-  apt-get install -y apt-transport-https \
+install_packages() {
+  apt-get install -y
+    apt-get install -y apt-transport-https \
     ca-certificates \
     curl \
-    software-properties-common
+    software-properties-common \
+    jq
+}
+
+install_packages
+
+## Install and setup Docker
+docker_setup() {
+  : "${DOCKER_CONFIG_FILE:=/etc/default/docker}"
 
   if [[ ! -f $DOCKER_APT_FILE ]]; then
     curl -fsSL 'https://download.docker.com/linux/ubuntu/gpg' | apt-key add -


### PR DESCRIPTION
This is the first iteration to ship a systemd-enabled installer for our Enterprise workers. This installer comes with less features than the previous upstart-based ones, mostly because we're relying on a different Docker storage driver these days. Back then it used `aufs` and `devicemapper` where especially the latter required more setup ceremony and a specific hardware configuration. So far we rely on `overlay2` exclusively for now.

Also we're replicating as much as we can the setup travis-ci.com is using on their AWS EC2 build machines which will very likely reduce maintenance for us. This also means that we don't ship any `.rpm` or `.deb` packages anymore but running `travis-worker` in a Docker container, too. This means that we're now in charge of shipping our own configuration files, which have been included in the package before.

Another notable change is that we're now having a service user, namely `travis`. This user is used to run travis-worker.