### PR TITLE
Require minimum disk space

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -90,8 +90,7 @@ require_minimum_disk_space() {
   local root_disk_space=""
   root_disk_space="$(df -k / | tail -1 | awk '{print $2}')"
   # 40593708 == 40GB
-  if [ $((root_disk_space)) -lt 40593708 ]
-  then
+  if [[ $((root_disk_space)) -lt 40593708 ]]; then
     echo "You need at least 40GB of total disk space for the root file system"
     exit 1
   fi

--- a/installer.sh
+++ b/installer.sh
@@ -87,11 +87,10 @@ root_check
 ##
 
 require_minimum_disk_space() {
-  local root_disk_space="$(df -k / | tail -1 | awk '{print $4}')"
-  # 39545852 ~= 39GB
-  # This odd number is caused by EC2. When a user requests a 40GB harddisk, they
-  # get 39GB in the end, which is already fine for us
-  if [ $((root_disk_space)) -lt 39545852 ]
+  local root_disk_space=""
+  root_disk_space="$(df -k / | tail -1 | awk '{print $2}')"
+  # 40593708 == 40GB
+  if [ $((root_disk_space)) -lt 40593708 ]
   then
     echo "You need at least 40GB of total disk space for the root file system"
     exit 1

--- a/installer.sh
+++ b/installer.sh
@@ -88,8 +88,10 @@ root_check
 
 require_minimum_disk_space() {
   local root_disk_space="$(df -k / | tail -1 | awk '{print $4}')"
-  # 39708844 == 40GB
-  if [ $((root_disk_space)) -lt 39708844 ]
+  # 39545852 ~= 39GB
+  # This odd number is caused by EC2. When a user requests a 40GB harddisk, they
+  # get 39GB in the end, which is already fine for us
+  if [ $((root_disk_space)) -lt 39545852 ]
   then
     echo "You need at least 40GB of total disk space for the root file system"
     exit 1

--- a/installer.sh
+++ b/installer.sh
@@ -86,6 +86,18 @@ root_check() {
 root_check
 ##
 
+require_minimum_disk_space() {
+  local root_disk_space="$(df -k / | tail -1 | awk '{print $4}')"
+  # 39708844 == 40GB
+  if [ $((root_disk_space)) -lt 39708844 ]
+  then
+    echo "You need at least 40GB of total disk space for the root file system"
+    exit 1
+  fi
+}
+
+require_minimum_disk_space
+
 install_packages() {
   apt-get install -y
     apt-get install -y apt-transport-https \


### PR DESCRIPTION
Resolves #8 

We require ~40GB of minimum disk space. If that's not given, the installer bails out. We want 40GB to ensure that there's enough space to accommodate all build images + some headroom for potential image updates.