### PR TITLE
Only generate /etc/default/travis-worker

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -87,6 +87,12 @@ else
   export BUILD_IMAGES='precise'
 fi
 
+if [[ ! -n $TRAVIS_ENTERPRISE_BUILD_ENDPOINT ]]; then
+  export TRAVIS_ENTERPRISE_BUILD_ENDPOINT="__build__"
+else
+  export TRAVIS_ENTERPRISE_BUILD_ENDPOINT
+fi
+
 ## We only want to run as root
 root_check() {
   if [[ $(whoami) != "root" ]]; then
@@ -250,32 +256,17 @@ else
 fi
 
 configure_travis_worker() {
-  TRAVIS_ENTERPRISE_CONFIG="/etc/default/travis-enterprise"
   TRAVIS_WORKER_CONFIG="/etc/default/travis-worker"
 
   # Trusty images don't seem to like SSH
   # shellcheck disable=SC2129
   echo "export TRAVIS_WORKER_DOCKER_NATIVE=\"true\"" >> $TRAVIS_WORKER_CONFIG
   echo "export AMQP_URI=\"amqp://travis:${TRAVIS_ENTERPRISE_SECURITY_TOKEN:-travis}@${TRAVIS_ENTERPRISE_HOST:-localhost}/travis\"" >> $TRAVIS_WORKER_CONFIG
-  echo "export BUILD_API_URI=\"https://${TRAVIS_ENTERPRISE_HOST:-localhost}/${TRAVIS_ENTERPRISE_BUILD_ENDPOINT:-}/script\"" >> $TRAVIS_WORKER_CONFIG
+  echo "export BUILD_API_URI=\"https://${TRAVIS_ENTERPRISE_HOST:-localhost}/${TRAVIS_ENTERPRISE_BUILD_ENDPOINT:-__build__}/script\"" >> $TRAVIS_WORKER_CONFIG
   echo "export TRAVIS_WORKER_BUILD_API_INSECURE_SKIP_VERIFY='true'" >> $TRAVIS_WORKER_CONFIG
   echo "export POOL_SIZE='2'" >> $TRAVIS_WORKER_CONFIG
   echo "export PROVIDER_NAME='docker'" >> $TRAVIS_WORKER_CONFIG
   echo "export TRAVIS_WORKER_DOCKER_ENDPOINT='tcp://localhost:4243'" >> $TRAVIS_WORKER_CONFIG
-
-  if [[ -n $TRAVIS_ENTERPRISE_HOST ]]; then
-    echo "export TRAVIS_ENTERPRISE_HOST=\"$TRAVIS_ENTERPRISE_HOST\"" >> $TRAVIS_ENTERPRISE_CONFIG
-  fi
-
-  if [[ -n $TRAVIS_ENTERPRISE_SECURITY_TOKEN ]]; then
-    echo "export TRAVIS_ENTERPRISE_SECURITY_TOKEN=\"$TRAVIS_ENTERPRISE_SECURITY_TOKEN\"" >> $TRAVIS_ENTERPRISE_CONFIG
-  fi
-
-  if [[ -n $TRAVIS_ENTERPRISE_BUILD_ENDPOINT ]]; then
-    echo "export TRAVIS_ENTERPRISE_BUILD_ENDPOINT=\"$TRAVIS_ENTERPRISE_BUILD_ENDPOINT\"" >> $TRAVIS_ENTERPRISE_CONFIG
-  else
-    echo "export TRAVIS_ENTERPRISE_BUILD_ENDPOINT=\"__build__\"" >> $TRAVIS_ENTERPRISE_CONFIG
-  fi
 
   if [[ -n $TRAVIS_QUEUE_NAME ]]; then
     echo "export QUEUE_NAME='$TRAVIS_QUEUE_NAME'" >> $TRAVIS_WORKER_CONFIG

--- a/installer.sh
+++ b/installer.sh
@@ -286,4 +286,4 @@ fi
 systemctl start travis-worker
 
 echo 'Installation complete.'
-echo 'It is recommended that this host is restarted before running jobs through it'
+echo 'It is recommended to restart this host before it is used to run any jobs'


### PR DESCRIPTION
We decided that it's time to say goodbye to `/etc/default/travis-enterprise` since all relevant configuration is happening in `/etc/default/travis-worker`. 

This also fixes the missing build endpoint for the build api env variable (#Resolves #12).