### PR TITLE
Run apt-get update before installing anything

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -111,6 +111,9 @@ require_minimum_disk_space() {
 require_minimum_disk_space
 
 install_packages() {
+  # This is necessary because usually package sources are not up to date yet when this script runs.
+  apt-get update
+
   apt-get install -y
     apt-get install -y apt-transport-https \
     ca-certificates \


### PR DESCRIPTION
This is necessary because people run this script on their brand new EC2 VM and these usually don't have their package sources up to date when they're booted the first time.

Resolves #6 