### PR TITLE
use domain socket to connect to docker

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -269,7 +269,7 @@ configure_travis_worker() {
   echo "export TRAVIS_WORKER_BUILD_API_INSECURE_SKIP_VERIFY='true'" >> $TRAVIS_WORKER_CONFIG
   echo "export POOL_SIZE='2'" >> $TRAVIS_WORKER_CONFIG
   echo "export PROVIDER_NAME='docker'" >> $TRAVIS_WORKER_CONFIG
-  echo "export TRAVIS_WORKER_DOCKER_ENDPOINT='tcp://localhost:4243'" >> $TRAVIS_WORKER_CONFIG
+  echo "export TRAVIS_WORKER_DOCKER_ENDPOINT='unix:///var/run/docker.sock'" >> $TRAVIS_WORKER_CONFIG
 
   if [[ -n $TRAVIS_QUEUE_NAME ]]; then
     echo "export QUEUE_NAME='$TRAVIS_QUEUE_NAME'" >> $TRAVIS_WORKER_CONFIG


### PR DESCRIPTION
On Xenial and later Docker is not listening on a TCP port by default but on a domain socket and gets activated on demand. Therefore we also need to change the way how travis-worker talks to Docker.