### PR TITLE
create missing run dir

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -270,6 +270,13 @@ else
   echo "Skip populating build images"
 fi
 
+create_run_dir() {
+  mkdir -p /var/tmp/travis-run.d/
+  chown -R travis:travis /var/tmp/travis-run.d/
+}
+
+create_run_dir
+
 configure_travis_worker() {
   TRAVIS_WORKER_CONFIG="/etc/default/travis-worker"
 


### PR DESCRIPTION
This PR creates a missing run directory which is required for travis-worker to operate properly. This fix was already documented in our operations manual [here](https://docs.travis-ci.com/user/enterprise/operations-manual/#travis-worker-on-Ubuntu-16.04-does-not-start), back then considered a one-off situation which *could* happen but wasn't expected to happen every time. Now after a couple of support requests with people running into this problem on a regular basis, I started investigating again, finding out that this needs to be fixed in the installer.