### PR TITLE
 Silence the metrics in travis-worker.log

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -313,6 +313,7 @@ configure_travis_worker() {
   echo "export POOL_SIZE='2'" >> $TRAVIS_WORKER_CONFIG
   echo "export PROVIDER_NAME='docker'" >> $TRAVIS_WORKER_CONFIG
   echo "export TRAVIS_WORKER_DOCKER_ENDPOINT='unix:///var/run/docker.sock'" >> $TRAVIS_WORKER_CONFIG
+  echo "export SILENCE_METRICS=\"true\"" >> $TRAVIS_WORKER_CONFIG
 
   if [[ -n $TRAVIS_QUEUE_NAME ]]; then
     echo "export QUEUE_NAME='$TRAVIS_QUEUE_NAME'" >> $TRAVIS_WORKER_CONFIG


### PR DESCRIPTION
The metrics currently clutter the logs too much and don't provide any additional, therefore we're disabling them for our Enterprise customers.