### PR TITLE
Fix docker version

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -80,7 +80,8 @@ while [ $# -gt 0 ]; do
 done
 
 if [[ -z $DOCKER_VERSION ]]; then
-  export DOCKER_VERSION="5:19.03.12~3-0~ubuntu"
+  DOCKER_VERSION_STR="5:19.03.12~3-0~ubuntu-$(lsb_release -cs)"
+  export DOCKER_VERSION=$DOCKER_VERSION_STR
 else
   export DOCKER_VERSION
 fi

--- a/installer.sh
+++ b/installer.sh
@@ -80,7 +80,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [[ -z $DOCKER_VERSION ]]; then
-  export DOCKER_VERSION="18.06.1~ce~3-0~ubuntu"
+  export DOCKER_VERSION="5:19.03.12~3-0~ubuntu"
 else
   export DOCKER_VERSION
 fi


### PR DESCRIPTION
This PR adjusts the Docker version to the latest available and also takes into account Docker's new version name schema. 
This change is necessary to allow people to install workers on Ubuntu 20.04 servers. 

I tested this change on:

- Ubuntu 16.04
- Ubuntu 18.04
- Ubuntu 20.04